### PR TITLE
Add Valkey base service

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These are individual service setups that can be used as building blocks for your
 - **Kafka with Kafka UI**: Kafka message broker with a management UI.
 - **MinIO**: High-performance object storage service.
 - **Redis with RedisInsight**: In-memory data store with a management UI.
+- **Valkey**: Drop-in Redis replacement managed by the Linux Foundation.
 - **RabbitMQ**: Reliable messaging between distributed systems.
 - **Qdrant Vector DB**: Optimized for storing and searching high-dimensional vectors.
 - **Milvus Vector DB**: Open-source vector database for similarity search.
@@ -36,7 +37,7 @@ These are pre-configured setups combining multiple services for specific use cas
 - ⬜ **Great Expectations**
 - ⬜ **BentoML**
 - ⬜ **Nvidia Triton**
-- ⬜ **Valkey**
+- ✅ **Valkey** added to base
 
 ### Legend:
 - ✅ Completed

--- a/base/valkey/README.md
+++ b/base/valkey/README.md
@@ -1,0 +1,2 @@
+docker compose up -d
+docker compose down

--- a/base/valkey/compose.yaml
+++ b/base/valkey/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  valkey:
+    image: valkey/valkey:latest
+    container_name: valkey
+    ports:
+      - "6379:6379"
+    volumes:
+      - valkey_data:/data
+    networks:
+      - valkey_network
+
+volumes:
+  valkey_data:
+    driver: local
+    driver_opts:
+      type: none
+      device: ./valkey_data
+      o: bind
+
+networks:
+  valkey_network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add compose and README for Valkey service
- document Valkey in main README and mark it complete in TODO list

## Testing
- `yamllint base/valkey/compose.yaml`

------
https://chatgpt.com/codex/tasks/task_e_683ff5f02aa88326ac1a3080aba8e3d8